### PR TITLE
use version checker correctly (fixes ember version resolution for yarn workspaces)

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
 
   ensureEmberVersion() {
     if (!this.emberVersion) {
-      let checker = new VersionChecker(this);
+      let checker = new VersionChecker(this.project);
       this.emberVersion = checker.for(`ember-source`);
       debug(`Detected Ember version ${this.emberVersion.version}`);
     }


### PR DESCRIPTION
Based on the readme from ember-cli-version-checker - https://github.com/ember-cli/ember-cli-version-checker#should-i-use-project-or-parent

That last section mentions explicitly that `VersionChecker(this)` is invalid, and we should be using `this.project` or `this.parent`

This seems to fix issues when using this package in monorepo projects using yarn workspaces, when the polyfill is hoisted. Since this polyfills package only has a single 1.0.0 version, it's pretty likely in any workspace scenario it'll get hoisted to root and be a shared package in some way.

---

Further reading;
I came across this, when updating several addons in a monorepo from Ember 3.16 to 3.20. Once the majority were updated, ember-source 3.20 was hoisted, and the remaining addons that used ember-in-element-polyfills in some way were then being incorrectly detected as 3.20 by this package before they were actually updated - causing them not to have the in-element polyfills included when they still needed them, so they would fail their builds & tests.

When the version checker is used with just `this`, and both ember-source and ember-in-element-polyfills has been hoisted, it uses the hoisted ember-source version, instead of using yarn to correctly resolve the ember-source version.